### PR TITLE
Clean .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
-test
+# config
+.gitignore
+.travis.yml
+.npmignore
+
+# tests
 test.js
-docs
-example
-examples


### PR DESCRIPTION
Prevent unnecessary files from being uploaded to npm. Saves filesize > improve install speed.
